### PR TITLE
Implement graceful program exit by catching CTRL + C

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1,6 +1,7 @@
 #include <iostream> // << operator and such
 #include <dirent.h> // File system operations
 #include <typeinfo>
+#include <poll.h>
 
 #include <chrono> // Execution time measurement
 #include <thread> // Threads
@@ -31,6 +32,9 @@
 #include <sys/socket.h> // for socket creation
 #include <netinet/in.h> //contains constants and structures needed for internet domain addresses
 
+#include <signal.h>
+#include <unistd.h>
+#include <cstring>
 #include <atomic>
 
 #include <iomanip> // 


### PR DESCRIPTION
This PR introduces a handler for CTRL + C to prevent suddenly killing any running threads. The PR will help in fixing #80 by making IO asynchronous, which in turn requires an exit handler to synchronize IO again in order to avoid log corruption.

This fixes #8 .